### PR TITLE
Prevent crash when return value from tested function is undefined.

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -12,6 +12,7 @@ var path = require('path'),
 
 function stringify(obj) {
     var string = JSON.stringify(obj, null, " ");
+    if (typeof string === 'undefined') string = 'undefined';
 
     // reduce a few linebreaks
     string = string.replace(/([^,])[\r\n]+/g, "$1");


### PR DESCRIPTION
I forgot the return statement on the first example, and ended up with a callstack instead of a failure.

This should make for easier debugging when someone does that.
