### PR TITLE
Make Todo-Template run/verify better conform to problem description

### DIFF
--- a/exercises/9_todo_template/exercise.js
+++ b/exercises/9_todo_template/exercise.js
@@ -10,21 +10,21 @@ var run = {
         "Tom": [
             {
                 todo: "Clean kitchen",
-                date: moment().add(10, 'days')
+                date: moment().add(10, 'days').toJSON()
             },
             {
                 todo: "Lean Lo-Dash",
-                date: moment().add(1, 'days')
+                date: moment().add(1, 'days').toJSON()
             },
             {
                 todo: "Become a Lo-Dash master",
-                date: moment().add(3, 'days')
+                date: moment().add(3, 'days').toJSON()
             }
         ],
         "Tim": [
             {
                 todo: "Contibute to an Open-Sorce-Project",
-                date: moment().add(2, 'days')
+                date: moment().add(2, 'days').toJSON()
             }
         ]
     },
@@ -54,19 +54,19 @@ var testing = {
             Martin: [
                 {
                     todo: "1",
-                    date: moment().add(3, 'days')
+                    date: moment().add(3, 'days').toJSON()
                 },
                 {
                     todo: "2",
-                    date: moment().add(2, 'days')
+                    date: moment().add(2, 'days').toJSON()
                 },
                 {
                     todo: "3",
-                    date: moment().add(1, 'days')
+                    date: moment().add(1, 'days').toJSON()
                 },
                 {
                     todo: "4",
-                    date: moment().add(10, 'days')
+                    date: moment().add(10, 'days').toJSON()
                 }
             ]
         },
@@ -77,11 +77,11 @@ var testing = {
             Martin: [
                 {
                     todo: "1",
-                    date: moment().add(2, 'days').add(1, 'hours')
+                    date: moment().add(2, 'days').add(1, 'hours').toJSON()
                 },
                 {
                     todo: "1",
-                    date: moment().add(1, 'days').add(23, 'hours')
+                    date: moment().add(1, 'days').add(23, 'hours').toJSON()
                 }
 
             ]


### PR DESCRIPTION
Hi there!

The problem desc for 9_todo_template states we get pure JSON as input, with dates as ISO Strings. But the exercice code sends Moment instances in, which will not work on any submitted code that assumes the passed info is indeed strings, and doesn't attempt to convert it back to `Date`.

For instance, the most performant solution here would be to compute the ISO String for "in 2 days" once and for all, and use `String` comparison after that, ISO Strings being lexically comparable. No need to convert the passed `todo.date` back as a `Date` object.

There's a masked requirement on solution implementation here, that favors less-performant solutions to boot.

I just changed the exercise code so that it does indeed pass pure JSON in, as per the problem description, so as not to limit solution code.

Cheers!