### PR TITLE
g11n: upgrade to latest workshopper infra and lib versions to bootstrap L10n

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ lololodash
   ```bat
   > npm install lololodash -g
   ```
-  
+
 4. Run the exercises.
   ```
   > lololodash

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,4 +1,16 @@
 {
   "title": "Lololodash - learn LoDash",
-  "subtitle": "\u001b[23mSelect an exercise and hit \u001b[3mEnter\u001b[23m to begin"
+  "subtitle": "\u001b[23mSelect an exercise and hit \u001b[3mEnter\u001b[23m to begin",
+  "common": {
+    "exercise": {
+      "logcompare": {
+        "input": "Input",
+        "output": "Output",
+        "output_should_be": "Output should be:"
+      },
+      "missing_deps": "You need to install all of the dependencies you are using in your solution (e.g. lodash)",
+      "module_not_found": "Could not find your file. Make sure the path is correct.",
+      "must_export_function": "You should always return a function using the module.exports object."
+    }
+  }
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "title": "Lololodash - learn LoDash",
+  "subtitle": "\u001b[23mSelect an exercise and hit \u001b[3mEnter\u001b[23m to begin"
+}

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,0 +1,15 @@
+{
+  "title": "Lololodash - Apprenez LoDash",
+  "subtitle" : "\u001b[23mSélectionnez un exercice et tapez \u001b[3mEnter\u001b[23m pour démarrer",
+  "exercise": {
+    "1: Getting Started": "1 : Démarrer",
+    "2: Sort Me": "2 : Trie-moi",
+    "3: In Every Case": "3 : Dans tous les cas",
+    "4: Everyone Is Min": "4 : Tout le monde est petit",
+    "5: Count the Comments": "5 : Compte les commentaires",
+    "6: Give Me an Overview": "6 : Fais-moi un résumé",
+    "7: Analyze": "7 : Analyse",
+    "8: Start templating": "8 : Commence les templates",
+    "9: ToDo Template": "9 : Template de To-Do"
+  }
+}

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -18,7 +18,7 @@ function stringify(obj) {
 
     // reduce a few linebreaks
     string = string.replace(/([^,])[\r\n]+/g, "$1");
-    string = string.replace(/{  "/g, '{ "');
+    string = string.replace(/\{  "/g, '{ "');
 
     // For templating-erercises (html-code line breaks)
     string = string.replace(/\\n/g, "\n");

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -76,6 +76,16 @@ function logcompare(input, output, shouldbe) {
 module.exports = function (tests, run) {
     var exercise = _.compose(execute, filecheck)(exerciser());
 
+    function i18nSafeHas(key) {
+        try {
+            return exercise.i18n.has(key);
+        } catch (e) {
+            // There's a corner case in i18n-core for keys with no '.' anywhere,
+            // which can happen for us due to missing trans and parent traversal.
+            return false;
+        }
+    }
+
     exercise.addProcessor(function (mode, callback) {
         var isRunMode = mode === 'run', self = this, usersolution, result;
 
@@ -100,7 +110,7 @@ module.exports = function (tests, run) {
             } catch (e) { }
 
             var expected = run.expect;
-            if ('string' === typeof expected && exercise.i18n.has(expected)) {
+            if ('string' === typeof expected && i18nSafeHas(expected)) {
                 expected = exercise.__(expected);
             }
 
@@ -118,7 +128,7 @@ module.exports = function (tests, run) {
         var allPassed = _(tests).map(function (item, element) {
             var isCorrect;
             var shouldbe = item.shouldbe;
-            if ('string' === typeof shouldbe && exercise.i18n.has(shouldbe)) {
+            if ('string' === typeof shouldbe && i18nSafeHas(shouldbe)) {
                 shouldbe = exercise.__(shouldbe);
             }
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -99,9 +99,14 @@ module.exports = function (tests, run) {
                 result = usersolution(run.json);
             } catch (e) { }
 
-            logcompare(run.json, result, run.expect);
+            var expected = run.expect;
+            if ('string' === typeof expected && exercise.i18n.has(expected)) {
+                expected = exercise.__(expected);
+            }
 
-            if (!result || !_.isEqual(clean(result), clean(run.expect))) {
+            logcompare(run.json, result, expected);
+
+            if (!result || !_.isEqual(clean(result), clean(expected))) {
                 this.emit('fail', 'Test');
                 return callback(null, false);
             }
@@ -112,13 +117,18 @@ module.exports = function (tests, run) {
 
         var allPassed = _(tests).map(function (item, element) {
             var isCorrect;
+            var shouldbe = item.shouldbe;
+            if ('string' === typeof shouldbe && exercise.i18n.has(shouldbe)) {
+                shouldbe = exercise.__(shouldbe);
+            }
+
             try {
-                isCorrect = _.isEqual(clean(item.shouldbe), clean(usersolution(item.input)));
+                isCorrect = _.isEqual(clean(shouldbe), clean(usersolution(item.input)));
             } catch (e) { }
 
             if (!isCorrect) {
                 self.emit('fail', element);
-                logcompare(item.input, usersolution(item.input), item.shouldbe);
+                logcompare(item.input, usersolution(item.input), shouldbe);
                 return false;
             }
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -58,16 +58,16 @@ function diffsould(shouldbe, output) {
     return string;
 }
 
-function logcompare(input, output, shouldbe) {
+function logcompare(input, output, shouldbe, __) {
     console.log([
         line(),
-        'Input',
+        __('logcompare.input'),
         line(),
         stringify(input),
         line(),
-        'Output:\n' + diffsould(stringify(output), stringify(shouldbe)),
+        __('logcompare.output') + '\n' + diffsould(stringify(output), stringify(shouldbe)),
         line(),
-        'Output should be:\n' + stringify(shouldbe),
+        __('logcompare.output_should_be') + '\n' + stringify(shouldbe),
         line()
     ].join('\n'));
 }
@@ -88,19 +88,21 @@ module.exports = function (tests, run) {
 
     exercise.addProcessor(function (mode, callback) {
         var isRunMode = mode === 'run', self = this, usersolution, result;
+        var __ = exercise.__.bind(exercise);
 
         try {
             usersolution = require(path.resolve(process.cwd(), this.args[0]));
         } catch (e) {
-            var message = (e.code !== 'MODULE_NOT_FOUND' ? 'Could not find your file. Make sure the path is correct.'
-                            : 'You need to install all of the dependencies you are using in your solution (e.g. lodash)');
+            var message = (e.code !== 'MODULE_NOT_FOUND'
+                            ? __('fail.module_not_found')
+                            : __('fail.missing_deps'));
 
             this.emit('fail', message);
             return callback(null, false);
         }
 
         if (typeof usersolution !== 'function') {
-            this.emit('fail', 'You should always return a function using the module.exports object.');
+            this.emit('fail', __('fail.must_export_function'));
             return callback(null, false);
         }
 
@@ -114,7 +116,7 @@ module.exports = function (tests, run) {
                 expected = exercise.__(expected);
             }
 
-            logcompare(run.json, result, expected);
+            logcompare(run.json, result, expected, __);
 
             if (!result || !_.isEqual(clean(result), clean(expected))) {
                 this.emit('fail', 'Test');
@@ -127,6 +129,10 @@ module.exports = function (tests, run) {
 
         var allPassed = _(tests).map(function (item, element) {
             var isCorrect;
+            if (i18nSafeHas(element)) {
+                element = exercise.__(element);
+            }
+
             var shouldbe = item.shouldbe;
             if ('string' === typeof shouldbe && i18nSafeHas(shouldbe)) {
                 shouldbe = exercise.__(shouldbe);
@@ -138,7 +144,7 @@ module.exports = function (tests, run) {
 
             if (!isCorrect) {
                 self.emit('fail', element);
-                logcompare(item.input, usersolution(item.input), shouldbe);
+                logcompare(item.input, usersolution(item.input), shouldbe, __);
                 return false;
             }
 

--- a/lololodash.js
+++ b/lololodash.js
@@ -15,9 +15,6 @@ function fpath(f) {
 
 workshopper({
     name        : 'lololodash',
-    title       : 'Lololodash - learn LoDash',
-    subtitle    : 'Learn Lo-Dash',
     appDir      : __dirname,
-    menuItems   : [],
-    exerciseDir : fpath('./exercises/')
+    languages   : ['en', 'fr']
 });

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "homepage": "https://github.com/mdunisch/lololodash",
   "dependencies": {
     "diff": "^1.2.2",
-    "lodash": "^3.1.0",
+    "lodash": "^3.2.0",
     "moment": "^2.9.0",
     "update-notifier": "^0.3.0",
-    "workshopper": "^2.2.0",
-    "workshopper-exercise": "^2.1.0"
+    "workshopper": "^2.3.1",
+    "workshopper-exercise": "^2.3.0"
   }
 }


### PR DESCRIPTION
Hey Martin!

First, gratz on `lololodash`, it's a cool workshop.

As part of the nodeschool/organizers#64 g11n effort currently underway, I'm bringing all `workshopper`-based workshops up to snuff on the latest versions of it so they can get translated (L10n) readily.

I'm also bringing them on the latest versions of their tested libs, and re-testing all the exercises, to reduce the risk of obsolescence.

As your workshop was on a very recent version of `workshopper`, it needed very little changes on the i18n side. This is a short PR for that aspect.

Expect another PR within 24 hours with the FR L10n.  I hope you see this favorably. We're hosting the first Paris NodeSchool session this Saturday, and it would be fantastic if this could all be merged in and bumped in npm by then :smile: 

I am, of course, available for all questions and discussions on this.

Best,