### PR TITLE
Add colors-tmpl to dependencies

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -6,7 +6,7 @@ var path = require('path'),
     filecheck = require('workshopper-exercise/filecheck'),
     execute = require('workshopper-exercise/execute'),
     jsdiff = require("diff"),
-    colorsTmpl = require('workshopper/node_modules/colors-tmpl');
+    colorsTmpl = require('colors-tmpl');
 
 
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/mdunisch/lololodash",
   "dependencies": {
     "babel": "^5.8.23",
+    "colors-tmpl": "~0.1.0",
     "diff": "^2.1.3",
     "lodash": "^3.10.1",
     "moment": "^2.10.6",


### PR DESCRIPTION
Fixes nodeschool/discussions#1502

When installed with npm@3.x, `workshopper`'s dependency `colors-tmpl` is located at the top-level node_modules directory (and lololodash won't run). If we add it to the lololodash dependencies, it should work everywhere (tested with npm@2.14.8 and 3.3.8).
