### PR TITLE
Fix nesting of en.json

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,9 +8,11 @@
         "output": "Output",
         "output_should_be": "Output should be:"
       },
-      "missing_deps": "You need to install all of the dependencies you are using in your solution (e.g. lodash)",
-      "module_not_found": "Could not find your file. Make sure the path is correct.",
-      "must_export_function": "You should always return a function using the module.exports object."
+      "fail": {
+        "missing_deps": "You need to install all of the dependencies you are using in your solution (e.g. lodash)",
+        "module_not_found": "Could not find your file. Make sure the path is correct.",
+        "must_export_function": "You should always return a function using the module.exports object."
+      }
     }
   }
 }


### PR DESCRIPTION
Hi @mdunisch ! Thanks for your greate workshopper!
I did `1: Getting Started` and did't write `module.exports`.
I try `verify` command and got an error like below.
`?exercises.1: Getting Started.fail.must_export_function || common.exercise.fail.must_export_function || fail.must_export_function?`

I checked `i18n/ko.json` and find that `"fail"` can't find in `i18n/en.json`.
I tried adding `"fail"` to `en.json` and run `verify` command.
It seems to good (error became to `You should always return a function using the module.exports object.`).

Thanks :)